### PR TITLE
Link for issues page in title

### DIFF
--- a/src/main/resources/templates/stats_table.html
+++ b/src/main/resources/templates/stats_table.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <table>
-    <caption><a href="https://github.com/openshiftio/openshift.io" >STATS FOR OSIO</a></caption>
+    <caption><a href="https://github.com/openshiftio/openshift.io/issues" >STATS FOR OSIO</a></caption>
     <thead>
     <tr>
         <th scope="col">Category</th>


### PR DESCRIPTION
This changes the link in the title to https://github.com/openshiftio/openshift.io/issues